### PR TITLE
Fixed plugins length and added important controller name

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -151,6 +151,7 @@ ON('controller', function(controller) {
 		}
 	}
 
+	controller.name = 'admin';
 	controller.user = user;
 });
 

--- a/views/admin.html
+++ b/views/admin.html
@@ -55,7 +55,7 @@
 			<main>
 				<div style="height:8px"></div>
 				@{foreach m in model}
-					@{if m.plugins.length !== 1}
+					@{if m.plugins.length !== 0}
 						@{if index > 0}
 						<hr />
 						@{fi}


### PR DESCRIPTION
`controller.name` is used in

```
var isAdmin = $.controller ? $.controller.name === 'admin' : false;
```

`$.controller.name` was always `unknown` before this commit