### PR TITLE
escape html special chars in name attribute

### DIFF
--- a/plugins/pages/public/form.html
+++ b/plugins/pages/public/form.html
@@ -287,6 +287,7 @@
 			var submit = function() {
 				var parts = { type: 'page', items: editor.getParts() };
 				FUNC.loading(true);
+				model.name = model.name.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#039;');
 				AJAX('POST [url]api/pages/ REPEAT', model, function(response) {
 					FUNC.loading(false, 1000);
 


### PR DESCRIPTION
I have escaped the html special characters from the name attribute in particular, however this should be done with all user-controllable inputs, this should close #35.

Now if you try to put the POC mentioned in the issue (`"><img src=x onerror=alert(1)>`) you will see the following:

![image](https://user-images.githubusercontent.com/66751764/155926572-4e19ead7-d042-40f9-969a-cd18cc603d0d.png)
